### PR TITLE
fix issue "server_addr is ignored in ~/.pgrok config"

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,6 +19,7 @@ Contributors to pgrok, both large and small:
 - Kyle Conroy 
 - Marcus Blankenship 
 - mattn 
+- Michał Jażdżyk
 - Muromi Rikka 
 - Nick Presta 
 - Otto Jongerius 

--- a/client/cli.go
+++ b/client/cli.go
@@ -118,7 +118,7 @@ func ParseArgs() (opts *Options, err error) {
 
 	serveraddr := flag.String(
 		"serveraddr",
-		defaultServerAddr,
+		"",
 		"The addr for server")
 
 	inspectaddr := flag.String(


### PR DESCRIPTION
This is quick fix for issue #7 